### PR TITLE
Added occa

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 * [fastd](http://fastdlabs.com/#/) - A High-Performance API Framework
 * [Xenus](https://abellion.github.io/xenus) - An elegant MongoDB ODM for PHP
 * [You-need-to-know-css](https://l-hammer.github.io/You-need-to-know-css/) - CSS tricks web developers need to know
+* [OCCA](http://libocca.org) - Library for programming multiple backends (OpenMP, CUDA, and OpenCL) with JIT compiled kernels
 
 ## Plugins
 


### PR DESCRIPTION
Thanks a ton for developing docsify, it's really awesome :)
It's one of the best templates I've seen
- Easy to use
- Extensible with plugins
- Good documentation

In case it's useful for docsify later, I added grouped tabs using [Vue material tabs](https://vuematerial.io/components/tabs/)

```
::: tabs <namespace>

- Tab1 Label
    My tab content

- Tab2 Label
    My tab content

:::
```

Example: http://libocca.org/#/occa/introduction?id=memory
